### PR TITLE
Remove incorrect delay from ConnectAndPublish()

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -3,7 +3,6 @@ package can
 import (
 	"io"
 	"net"
-	"time"
 )
 
 // Bus represents the CAN bus.
@@ -45,7 +44,6 @@ func (b *Bus) ConnectAndPublish() error {
 		if err != nil {
 			return err
 		}
-		<-time.After(time.Millisecond * 10)
 	}
 
 	return nil


### PR DESCRIPTION
Without this change the absolute maximum number of received messages per second is 100.  With this change, I can get the full 600 msg/s from my CAN bus and the CPU usage is lower.

Reading from "can0" on linux is blocking by default with this package so things Just Work in proper Go fashion without the sleep.